### PR TITLE
Improved performance deserialising a list of items when TypeNameHandling is enabled and all items are of a consistent type

### DIFF
--- a/Newtonsoft.Json/Resources/.generated/newtonsoft.json.js
+++ b/Newtonsoft.Json/Resources/.generated/newtonsoft.json.js
@@ -432,88 +432,88 @@ Bridge.assembly("Newtonsoft.Json", function ($asm, globals) {
                             var params = jsonCtor.pi || [];
 
                             if (isEnumerable) {
-								return function (raw) {
-									var args = [];
-									if (Bridge.Reflection.isAssignableFrom(System.Collections.IEnumerable, params[0].pt)) {
-										// If this non-empty list of items are all of the same type then we don't need to repeat the reflection work that determines what constructor to use (if any) for
-										// each one of them - we can call getInstanceBuilder just once and then reuse the returned function when we translate each item. With large lists that all contain
-										// objects that are precisely the same type, this can save a lot of work (and so reduce the deserialisation time signicantly). It will only work when TypeNameHandling
-										// is enabled, if not then we fall back to calling DeserializeObject every time (which is also what happens if the types of the items vary).									
-										var arr = [],
-											elementType = Bridge.Reflection.getGenericArguments(params[0].pt)[0] ||
-														  Bridge.Reflection.getGenericArguments(type)[0] ||
-														  System.Object,
-											commonElementInstanceBuilder;
-										if (settings && settings.TypeNameHandling && raw.length > 0 && raw[0]) {
-											var useSameInstanceBuilderForAllValues = true;
-											var firstElementTypeName = raw[0].$type;
-											if (!firstElementTypeName) {
-												useSameInstanceBuilderForAllValues = false;
-											}
-											else {
-												for (var i = 1; i < raw.length; i++) {
-													var nextElementTypeName = raw[i] ? raw[i].$type : null;
-													if (!nextElementTypeName || (nextElementTypeName !== firstElementTypeName)) {
-														useSameInstanceBuilderForAllValues = false;
-														break;
-													}
-												}
-											}
-											if (useSameInstanceBuilderForAllValues) {
-												commonElementInstanceBuilder = Newtonsoft.Json.JsonConvert.getInstanceBuilder(elementType, raw[0], settings);
-											}
-											else {
-												commonElementInstanceBuilder = null;
-											}
-										}
-										else {
-											commonElementInstanceBuilder = null;
-										}														  
-										for (var i = 0; i < raw.length; i++) {
-											var item = raw[i];
-											arr[i] = commonElementInstanceBuilder ? commonElementInstanceBuilder(item) : Newtonsoft.Json.JsonConvert.DeserializeObject(item, elementType, settings, true);
-										}
-										args.push(arr);
-										isList = true;
-									}
-									var v = Bridge.Reflection.invokeCI(jsonCtor, args);
-									return isList ? { $list: true, names: [], value: v } : { names: [], value: v };
-								};
+                                return function (raw) {
+                                    var args = [];
+                                    if (Bridge.Reflection.isAssignableFrom(System.Collections.IEnumerable, params[0].pt)) {
+                                        // If this non-empty list of items are all of the same type then we don't need to repeat the reflection work that determines what constructor to use (if any) for
+                                        // each one of them - we can call getInstanceBuilder just once and then reuse the returned function when we translate each item. With large lists that all contain
+                                        // objects that are precisely the same type, this can save a lot of work (and so reduce the deserialisation time signicantly). It will only work when TypeNameHandling
+                                        // is enabled, if not then we fall back to calling DeserializeObject every time (which is also what happens if the types of the items vary).									
+                                        var arr = [],
+                                            elementType = Bridge.Reflection.getGenericArguments(params[0].pt)[0] ||
+                                                          Bridge.Reflection.getGenericArguments(type)[0] ||
+                                                          System.Object,
+                                            commonElementInstanceBuilder;
+                                        if (settings && settings.TypeNameHandling && raw.length > 0 && raw[0]) {
+                                            var useSameInstanceBuilderForAllValues = true;
+                                            var firstElementTypeName = raw[0].$type;
+                                            if (!firstElementTypeName) {
+                                                useSameInstanceBuilderForAllValues = false;
+                                            }
+                                            else {
+                                                for (var i = 1; i < raw.length; i++) {
+                                                    var nextElementTypeName = raw[i] ? raw[i].$type : null;
+                                                    if (!nextElementTypeName || (nextElementTypeName !== firstElementTypeName)) {
+                                                        useSameInstanceBuilderForAllValues = false;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                            if (useSameInstanceBuilderForAllValues) {
+                                                commonElementInstanceBuilder = Newtonsoft.Json.JsonConvert.getInstanceBuilder(elementType, raw[0], settings);
+                                            }
+                                            else {
+                                                commonElementInstanceBuilder = null;
+                                            }
+                                        }
+                                        else {
+                                            commonElementInstanceBuilder = null;
+                                        }														  
+                                        for (var i = 0; i < raw.length; i++) {
+                                            var item = raw[i];
+                                            arr[i] = commonElementInstanceBuilder ? commonElementInstanceBuilder(item) : Newtonsoft.Json.JsonConvert.DeserializeObject(item, elementType, settings, true);
+                                        }
+                                        args.push(arr);
+                                        isList = true;
+                                    }
+                                    var v = Bridge.Reflection.invokeCI(jsonCtor, args);
+                                    return isList ? { $list: true, names: [], value: v } : { names: [], value: v };
+                                };
                             }
-							
-							return function (raw) {
-								var args = [];
-								var names = [];
-								var theKeys = Object.getOwnPropertyNames(raw).toString();
-								for (var i = 0; i < params.length; i++) {
-									var name = params[i].sn || params[i].n,
-										match = new RegExp(name, 'i').exec(theKeys);
+                            
+                            return function (raw) {
+                                var args = [];
+                                var names = [];
+                                var theKeys = Object.getOwnPropertyNames(raw).toString();
+                                for (var i = 0; i < params.length; i++) {
+                                    var name = params[i].sn || params[i].n,
+                                        match = new RegExp(name, 'i').exec(theKeys);
 
-									name = match && match.length > 0 ? match[0] : null;
+                                    name = match && match.length > 0 ? match[0] : null;
 
-									if (name) {
-										args[i] = Newtonsoft.Json.JsonConvert.DeserializeObject(raw[name], params[i].pt, settings, true);
-										names.push(name);
-									} else {
-										args[i] = Bridge.getDefaultValue(params[i].pt);
-									}
-								}
+                                    if (name) {
+                                        args[i] = Newtonsoft.Json.JsonConvert.DeserializeObject(raw[name], params[i].pt, settings, true);
+                                        names.push(name);
+                                    } else {
+                                        args[i] = Bridge.getDefaultValue(params[i].pt);
+                                    }
+                                }
 
-								return { names: names, value: Bridge.Reflection.invokeCI(jsonCtor, args) };
-							};
+                                return { names: names, value: Bridge.Reflection.invokeCI(jsonCtor, args) };
+                            };
                         }
                     }
-					
-					return function () {
-                    	return { names: [], value: Bridge.createInstance(type) };
-					};
+                    
+                    return function () {
+                        return { names: [], value: Bridge.createInstance(type) };
+                    };
                 },
 
                 createInstance: function (type, raw, settings) {
-					var builder = this.getInstanceBuilder(type, raw, settings);
-					return builder(raw);
-				},
-				
+                    var builder = this.getInstanceBuilder(type, raw, settings);
+                    return builder(raw);
+                },
+                
                 DeserializeObject: function (raw, type, settings, field) {
                     settings = settings || {};
                     if (type.$kind === "interface") {

--- a/Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -280,88 +280,88 @@
                             var params = jsonCtor.pi || [];
 
                             if (isEnumerable) {
-								return function (raw) {
-									var args = [];
-									if (Bridge.Reflection.isAssignableFrom(System.Collections.IEnumerable, params[0].pt)) {
-										// If this non-empty list of items are all of the same type then we don't need to repeat the reflection work that determines what constructor to use (if any) for
-										// each one of them - we can call getInstanceBuilder just once and then reuse the returned function when we translate each item. With large lists that all contain
-										// objects that are precisely the same type, this can save a lot of work (and so reduce the deserialisation time signicantly). It will only work when TypeNameHandling
-										// is enabled, if not then we fall back to calling DeserializeObject every time (which is also what happens if the types of the items vary).									
-										var arr = [],
-											elementType = Bridge.Reflection.getGenericArguments(params[0].pt)[0] ||
-														  Bridge.Reflection.getGenericArguments(type)[0] ||
-														  System.Object,
-											commonElementInstanceBuilder;
-										if (settings && settings.TypeNameHandling && raw.length > 0 && raw[0]) {
-											var useSameInstanceBuilderForAllValues = true;
-											var firstElementTypeName = raw[0].$type;
-											if (!firstElementTypeName) {
-												useSameInstanceBuilderForAllValues = false;
-											}
-											else {
-												for (var i = 1; i < raw.length; i++) {
-													var nextElementTypeName = raw[i] ? raw[i].$type : null;
-													if (!nextElementTypeName || (nextElementTypeName !== firstElementTypeName)) {
-														useSameInstanceBuilderForAllValues = false;
-														break;
-													}
-												}
-											}
-											if (useSameInstanceBuilderForAllValues) {
-												commonElementInstanceBuilder = Newtonsoft.Json.JsonConvert.getInstanceBuilder(elementType, raw[0], settings);
-											}
-											else {
-												commonElementInstanceBuilder = null;
-											}
-										}
-										else {
-											commonElementInstanceBuilder = null;
-										}														  
-										for (var i = 0; i < raw.length; i++) {
-											var item = raw[i];
-											arr[i] = commonElementInstanceBuilder ? commonElementInstanceBuilder(item) : Newtonsoft.Json.JsonConvert.DeserializeObject(item, elementType, settings, true);
-										}
-										args.push(arr);
-										isList = true;
-									}
-									var v = Bridge.Reflection.invokeCI(jsonCtor, args);
-									return isList ? { $list: true, names: [], value: v } : { names: [], value: v };
-								};
+                                return function (raw) {
+                                    var args = [];
+                                    if (Bridge.Reflection.isAssignableFrom(System.Collections.IEnumerable, params[0].pt)) {
+                                        // If this non-empty list of items are all of the same type then we don't need to repeat the reflection work that determines what constructor to use (if any) for
+                                        // each one of them - we can call getInstanceBuilder just once and then reuse the returned function when we translate each item. With large lists that all contain
+                                        // objects that are precisely the same type, this can save a lot of work (and so reduce the deserialisation time signicantly). It will only work when TypeNameHandling
+                                        // is enabled, if not then we fall back to calling DeserializeObject every time (which is also what happens if the types of the items vary).									
+                                        var arr = [],
+                                            elementType = Bridge.Reflection.getGenericArguments(params[0].pt)[0] ||
+                                                          Bridge.Reflection.getGenericArguments(type)[0] ||
+                                                          System.Object,
+                                            commonElementInstanceBuilder;
+                                        if (settings && settings.TypeNameHandling && raw.length > 0 && raw[0]) {
+                                            var useSameInstanceBuilderForAllValues = true;
+                                            var firstElementTypeName = raw[0].$type;
+                                            if (!firstElementTypeName) {
+                                                useSameInstanceBuilderForAllValues = false;
+                                            }
+                                            else {
+                                                for (var i = 1; i < raw.length; i++) {
+                                                    var nextElementTypeName = raw[i] ? raw[i].$type : null;
+                                                    if (!nextElementTypeName || (nextElementTypeName !== firstElementTypeName)) {
+                                                        useSameInstanceBuilderForAllValues = false;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                            if (useSameInstanceBuilderForAllValues) {
+                                                commonElementInstanceBuilder = Newtonsoft.Json.JsonConvert.getInstanceBuilder(elementType, raw[0], settings);
+                                            }
+                                            else {
+                                                commonElementInstanceBuilder = null;
+                                            }
+                                        }
+                                        else {
+                                            commonElementInstanceBuilder = null;
+                                        }														  
+                                        for (var i = 0; i < raw.length; i++) {
+                                            var item = raw[i];
+                                            arr[i] = commonElementInstanceBuilder ? commonElementInstanceBuilder(item) : Newtonsoft.Json.JsonConvert.DeserializeObject(item, elementType, settings, true);
+                                        }
+                                        args.push(arr);
+                                        isList = true;
+                                    }
+                                    var v = Bridge.Reflection.invokeCI(jsonCtor, args);
+                                    return isList ? { $list: true, names: [], value: v } : { names: [], value: v };
+                                };
                             }
-							
-							return function (raw) {
-								var args = [];
-								var names = [];
-								var theKeys = Object.getOwnPropertyNames(raw).toString();
-								for (var i = 0; i < params.length; i++) {
-									var name = params[i].sn || params[i].n,
-										match = new RegExp(name, 'i').exec(theKeys);
+                            
+                            return function (raw) {
+                                var args = [];
+                                var names = [];
+                                var theKeys = Object.getOwnPropertyNames(raw).toString();
+                                for (var i = 0; i < params.length; i++) {
+                                    var name = params[i].sn || params[i].n,
+                                        match = new RegExp(name, 'i').exec(theKeys);
 
-									name = match && match.length > 0 ? match[0] : null;
+                                    name = match && match.length > 0 ? match[0] : null;
 
-									if (name) {
-										args[i] = Newtonsoft.Json.JsonConvert.DeserializeObject(raw[name], params[i].pt, settings, true);
-										names.push(name);
-									} else {
-										args[i] = Bridge.getDefaultValue(params[i].pt);
-									}
-								}
+                                    if (name) {
+                                        args[i] = Newtonsoft.Json.JsonConvert.DeserializeObject(raw[name], params[i].pt, settings, true);
+                                        names.push(name);
+                                    } else {
+                                        args[i] = Bridge.getDefaultValue(params[i].pt);
+                                    }
+                                }
 
-								return { names: names, value: Bridge.Reflection.invokeCI(jsonCtor, args) };
-							};
+                                return { names: names, value: Bridge.Reflection.invokeCI(jsonCtor, args) };
+                            };
                         }
                     }
-					
-					return function () {
-                    	return { names: [], value: Bridge.createInstance(type) };
-					};
+                    
+                    return function () {
+                        return { names: [], value: Bridge.createInstance(type) };
+                    };
                 },
 
                 createInstance: function (type, raw, settings) {
-					var builder = this.getInstanceBuilder(type, raw, settings);
-					return builder(raw);
-				},
-				
+                    var builder = this.getInstanceBuilder(type, raw, settings);
+                    return builder(raw);
+                },
+                
                 DeserializeObject: function (raw, type, settings, field) {
                     settings = settings || {};
                     if (type.$kind === "interface") {

--- a/Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -67,7 +67,7 @@
                             return;
                         }
 
-                        return returnRaw ? null : this.stringify(null, formatting);
+                        return returnRaw ? null : Newtonsoft.Json.JsonConvert.stringify(null, formatting);
                     }
 
                     var objType = Bridge.getType(obj);
@@ -88,7 +88,7 @@
 
                     if (typeof obj === "function") {
                         var name = Bridge.getTypeName(obj);
-                        return returnRaw ? name : this.stringify(name, formatting);
+                        return returnRaw ? name : Newtonsoft.Json.JsonConvert.stringify(name, formatting);
                     } else if (typeof obj === "object") {
                         var type = possibleType || objType,
                             arr,
@@ -127,11 +127,11 @@
                         }
 
                         if (type === System.Globalization.CultureInfo) {
-                            return returnRaw ? obj.name : this.stringify(obj.name, formatting);
+                            return returnRaw ? obj.name : Newtonsoft.Json.JsonConvert.stringify(obj.name, formatting);
                         } else if (type === System.Guid) {
-                            return returnRaw ? obj.toString() : this.stringify(obj.toString(), formatting);
+                            return returnRaw ? obj.toString() : Newtonsoft.Json.JsonConvert.stringify(obj.toString(), formatting);
                         } else if (type === System.Uri) {
-                            return returnRaw ? obj.getAbsoluteUri() : this.stringify(obj.getAbsoluteUri(), formatting);
+                            return returnRaw ? obj.getAbsoluteUri() : Newtonsoft.Json.JsonConvert.stringify(obj.getAbsoluteUri(), formatting);
                         } else if (type === System.Int64) {
                             return obj.toJSON();
                         } else if (type === System.UInt64) {
@@ -140,12 +140,12 @@
                             return obj.toJSON();
                         } else if (type === System.DateTime) {
                             var d = System.DateTime.format(obj, "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK");
-                            return returnRaw ? d : this.stringify(d, formatting);
+                            return returnRaw ? d : Newtonsoft.Json.JsonConvert.stringify(d, formatting);
                         } else if (Bridge.isArray(null, type)) {
                             if (type.$elementType === System.Byte) {
                                 removeGuard();
                                 var json = System.Convert.toBase64String(obj);
-                                return returnRaw ? json : this.stringify(json, formatting);
+                                return returnRaw ? json : Newtonsoft.Json.JsonConvert.stringify(json, formatting);
                             }
 
                             arr = [];
@@ -156,9 +156,9 @@
 
                             obj = arr;
                         } else if (Bridge.Reflection.isEnum(type)) {
-                            return returnRaw ? obj : this.stringify(obj, formatting);
+                            return returnRaw ? obj : Newtonsoft.Json.JsonConvert.stringify(obj, formatting);
                         } else if (type === System.Char) {
-                            return returnRaw ? String.fromCharCode(obj) : this.stringify(String.fromCharCode(obj), formatting);
+                            return returnRaw ? String.fromCharCode(obj) : Newtonsoft.Json.JsonConvert.stringify(String.fromCharCode(obj), formatting);
                         } else if (Bridge.Reflection.isAssignableFrom(System.Collections.IDictionary, type)) {
                             var typesGeneric = System.Collections.Generic.Dictionary$2.getTypeParameters(type),
                                 typeKey = typesGeneric[0],
@@ -232,7 +232,7 @@
                         removeGuard();
                     }
 
-                    return returnRaw ? obj : this.stringify(obj, formatting);
+                    return returnRaw ? obj : Newtonsoft.Json.JsonConvert.stringify(obj, formatting);
                 },
 
                 createInstance: function (type, raw, settings) {

--- a/Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -283,12 +283,43 @@
 								return function (raw) {
 									var args = [];
 									if (Bridge.Reflection.isAssignableFrom(System.Collections.IEnumerable, params[0].pt)) {
+										// If this non-empty list of items are all of the same type then we don't need to repeat the reflection work that determines what constructor to use (if any) for
+										// each one of them - we can call getInstanceBuilder just once and then reuse the returned function when we translate each item. With large lists that all contain
+										// objects that are precisely the same type, this can save a lot of work (and so reduce the deserialisation time signicantly). It will only work when TypeNameHandling
+										// is enabled, if not then we fall back to calling DeserializeObject every time (which is also what happens if the types of the items vary).									
 										var arr = [],
 											elementType = Bridge.Reflection.getGenericArguments(params[0].pt)[0] ||
 														  Bridge.Reflection.getGenericArguments(type)[0] ||
-														  System.Object;
+														  System.Object,
+											commonElementInstanceBuilder;
+										if (settings && settings.TypeNameHandling && raw.length > 0 && raw[0]) {
+											var useSameInstanceBuilderForAllValues = true;
+											var firstElementTypeName = raw[0].$type;
+											if (!firstElementTypeName) {
+												useSameInstanceBuilderForAllValues = false;
+											}
+											else {
+												for (var i = 1; i < raw.length; i++) {
+													var nextElementTypeName = raw[i] ? raw[i].$type : null;
+													if (!nextElementTypeName || (nextElementTypeName !== firstElementTypeName)) {
+														useSameInstanceBuilderForAllValues = false;
+														break;
+													}
+												}
+											}
+											if (useSameInstanceBuilderForAllValues) {
+												commonElementInstanceBuilder = Newtonsoft.Json.JsonConvert.getInstanceBuilder(elementType, raw[0], settings);
+											}
+											else {
+												commonElementInstanceBuilder = null;
+											}
+										}
+										else {
+											commonElementInstanceBuilder = null;
+										}														  
 										for (var i = 0; i < raw.length; i++) {
-											arr[i] = Newtonsoft.Json.JsonConvert.DeserializeObject(raw[i], elementType, settings, true);
+											var item = raw[i];
+											arr[i] = commonElementInstanceBuilder ? commonElementInstanceBuilder(item) : Newtonsoft.Json.JsonConvert.DeserializeObject(item, elementType, settings, true);
 										}
 										args.push(arr);
 										isList = true;

--- a/Tests/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Tests/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Issues\0100\Case010.cs" />
     <Compile Include="Issues\0100\Case050.cs" />
     <Compile Include="Issues\0100\Case052.cs" />
+    <Compile Include="Tests\ListOptimisationTests.cs" />
     <Compile Include="Tests\DeserializationTests.cs" />
     <Compile Include="Issues\Ported\N1134.cs" />
     <Compile Include="Issues\Ported\N1438.cs" />

--- a/Tests/Newtonsoft.Json.Tests/Tests/ListOptimisationTests.cs
+++ b/Tests/Newtonsoft.Json.Tests/Tests/ListOptimisationTests.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Bridge.Test.NUnit;
+
+namespace Newtonsoft.Json.Tests
+{
+	[Category("ListOptimisations")]
+    [TestFixture]
+    public class ListOptimisationTests
+    {
+        /// <summary>
+        /// The list deserialisation optimisation should apply to this data because each item in the list is of exactly the same type
+        /// </summary>
+        [Test]
+        public static void EnsureThatAppliedOptimisationDoesNotBreakListDeserialisation()
+        {
+            var items = new NonNullList<KeyValuePairDataModel>(new[]
+            {
+                new KeyValuePairDataModel(),
+                new KeyValuePairDataModel()
+            });
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects };
+
+            var json = JsonConvert.SerializeObject(items, settings);
+            var cloneAsArray = JsonConvert.DeserializeObject<NonNullList<KeyValuePairDataModel>>(json, settings).ToArray();
+
+            Assert.AreEqual(2, cloneAsArray.Length);
+            Assert.AreEqual(typeof(KeyValuePairDataModel), cloneAsArray[0].GetType());
+            Assert.AreEqual(typeof(KeyValuePairDataModel), cloneAsArray[1].GetType());
+        }
+
+        /// <summary>
+        /// The optimisation should NOT apply to this data since there are different types in the list (this test is to ensure that the optimisation checks didn't break anything in
+        /// the non-optimisation paths)
+        /// </summary>
+        [Test]
+        public static void EnsureThatOptimisationDoesNotBreakListDeserialisationWhereItIsNotApplicable()
+        {
+            var items = new NonNullList<KeyValuePairDataModelBase>(new KeyValuePairDataModelBase[]
+            {
+                new KeyValuePairDataModel(),
+                new AlternativeKeyValuePairDataModel()
+            });
+            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects };
+
+            var json = JsonConvert.SerializeObject(items, settings);
+            var cloneAsArray = JsonConvert.DeserializeObject<NonNullList<KeyValuePairDataModelBase>>(json, settings).ToArray();
+
+            Assert.AreEqual(2, cloneAsArray.Length);
+            Assert.AreEqual(typeof(KeyValuePairDataModel), cloneAsArray[0].GetType());
+            Assert.AreEqual(typeof(AlternativeKeyValuePairDataModel), cloneAsArray[1].GetType());
+        }
+
+        public sealed class KeyValuePairDataModel : KeyValuePairDataModelBase
+        {
+        }
+
+        public sealed class AlternativeKeyValuePairDataModel : KeyValuePairDataModelBase
+        {
+        }
+
+        public abstract class KeyValuePairDataModelBase
+        {
+        }
+        public sealed class NonNullList<T> : IEnumerable<T>
+        {
+            private readonly Node _headIfAny;
+            private NonNullList(Node headIfAny)
+            {
+                _headIfAny = headIfAny;
+            }
+            public NonNullList(IEnumerable<T> values)
+            {
+                Node node = null;
+                foreach (var value in values.Reverse())
+                {
+                    node = new Node
+                    {
+                        Count = ((node == null) ? 0 : node.Count) + 1,
+                        Item = value,
+                        NextIfAny = node
+                    };
+                }
+                _headIfAny = node;
+            }
+
+            public uint Count { get { return (_headIfAny == null) ? 0 : (uint)_headIfAny.Count; } }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                var node = _headIfAny;
+                while (node != null)
+                {
+                    yield return node.Item;
+                    node = node.NextIfAny;
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() { return GetEnumerator(); }
+
+            private sealed class Node
+            {
+                public int Count;
+                public T Item;
+                public Node NextIfAny;
+            }
+        }
+    }
+}


### PR DESCRIPTION
From PR #46 (which I'm about to cancel in favour of this one):

I've been finding the deserialisation performance slow with larger object graphs and so I've been looking for any easy wins. The slowest objects we're working with at the moment have large lists of items and I noticed that reflection work was being repeated for every item in the list, in order to deserialise them - each time the code has to work out what constructor (if any) to use. I thought that we might be able to avoid doing this work over and over again in cases where we know that every item in the list is the same type, which we can find out if TypeNameHandling is enabled.

In my real world usage tests, this change has reduced deserialisation times considerably - often halving them.

I also wondered if you've had any thoughts about including performance tests in this repo somehow? Since this JSON.NET implementation is likely to get a lot of use (certainly, we're using it in our server-client commuications, which are key to the application) then any performance degradation introduced in future versions could have serious consequences. Was there talk at one point of translating from the Newtonson JSON.NET source code, once more of the .NET framework (such as System.IO) was available? That sounds appealing from a point of view of functionality but it could also reduce performance when compared to the current hand-written JavaScript approach.